### PR TITLE
Rebuild 2.35.1 for all missing platforms

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,18 +10,26 @@ set -e
 #    ln -sf "${fn}" "${new_fn}"
 #    varname=$(basename "${new_fn}" | tr a-z A-Z | sed "s/+/X/g" | sed "s/\./_/g" | sed "s/-/_/g")
 #    echo "$varname $CC"
-#    printf -v "$varname" "$BUILD_PREFIX/bin/${new_fn}"       
+#    printf -v "$varname" "$BUILD_PREFIX/bin/${new_fn}"
 #  done
 #popd
 
-for file in ./crosstool_ng/packages/binutils/$PKG_VERSION/*.patch; do
+for file in ./crosstool_ng/packages/binutils/${PKG_VERSION}/*.patch; do
   patch -p1 < $file;
 done
 
 mkdir build
 cd build
 
-export HOST="${ctng_cpu_arch}-${ctng_vendor}-linux-gnu"
+if [[ "$target_platform" == "osx-64" ]]; then
+  export CPPFLAGS="$CPPFLAGS -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+  export CFLAGS="$CFLAGS -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+  export CXXFLAGS="$CXXFLAGS -mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}"
+  export LDFLAGS="$LDFLAGS -Wl,-pie -Wl,-headerpad_max_install_names -Wl,-dead_strip_dylibs"
+fi
+export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
+
+export HOST="${ctng_cpu_arch}-conda-linux-gnu"
 
 ../configure \
   --prefix="$PREFIX" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-
 #pushd ${BUILD_PREFIX}/bin
 #  for fn in "${BUILD}-"*; do
 #    new_fn=${fn//${BUILD}-/}
@@ -14,7 +13,9 @@ set -e
 #  done
 #popd
 
-for file in ./crosstool_ng/packages/binutils/${PKG_VERSION}/*.patch; do
+# make sure version is just major-minor
+CTNG_VER=$(echo ${PKG_VERSION} | sed -nE 's/([0-9]+\.[0-9]+).*/\1/p')
+for file in ./crosstool_ng/packages/binutils/${CTNG_VER}/*.patch; do
   patch -p1 < $file;
 done
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,9 +3,11 @@ ctng_cpu_arch:
   - x86_64          # [not linux32]
   - powerpc64le     # [not linux32]
   - aarch64         # [not linux32]
+  - s390x           # [not linux32]
 ctng_vendor:
   - conda_cos6      # [linux32]
-  - conda_cos6      # [not linux32]
+  - conda_cos7      # [not linux32]
+  - conda_cos7      # [not linux32]
   - conda_cos7      # [not linux32]
   - conda_cos7      # [not linux32]
 ctng_target_platform:
@@ -13,6 +15,7 @@ ctng_target_platform:
   - linux-64        # [not linux32]
   - linux-ppc64le   # [not linux32]
   - linux-aarch64   # [not linux32]
+  - linux-s390x     # [not linux32]
 
 zip_keys:
   -

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,21 @@
 ctng_cpu_arch:
-  - i686  # [linux32]
-  - x86_64  # [linux64]
-  - powerpc64le  # [ppc64le]
-  - aarch64  # [aarch64]
+  - i686            # [linux32]
+  - x86_64          # [not linux32]
+  - powerpc64le     # [not linux32]
+  - aarch64         # [not linux32]
 ctng_vendor:
-  - conda_cos6  # [linux32 or linux64]
-  - conda_cos7  # [aarch64 or ppc64le]
+  - conda_cos6      # [linux32]
+  - conda_cos6      # [not linux32]
+  - conda_cos7      # [not linux32]
+  - conda_cos7      # [not linux32]
+ctng_target_platform:
+  - linux-32        # [linux32]
+  - linux-64        # [not linux32]
+  - linux-ppc64le   # [not linux32]
+  - linux-aarch64   # [not linux32]
 
+zip_keys:
+  -
+    - ctng_cpu_arch
+    - ctng_vendor
+    - ctng_target_platform

--- a/recipe/install_binutils.sh
+++ b/recipe/install_binutils.sh
@@ -5,9 +5,20 @@ set -e
 cd build
 
 make install-strip
-
+export HOST="${ctng_cpu_arch}-conda-linux-gnu"
+export OLD_HOST="${ctng_cpu_arch}-${ctng_vendor}-linux-gnu"
+mkdir -p $PREFIX/$OLD_HOST/bin
 # Remove hardlinks and replace them by softlinks
-for tool in addr2line ar as c++filt dwp elfedit gprof ld ld.bfd ld.gold nm objcopy objdump ranlib readelf size strings strip; do
+for tool in addr2line ar as c++filt dwp elfedit gprof ld.bfd ld.gold nm objcopy objdump ranlib readelf size strings strip; do
   rm -rf $PREFIX/$HOST/bin/$tool
   ln -s $PREFIX/bin/$HOST-$tool $PREFIX/$HOST/bin/$tool || true;
+  ln -s $PREFIX/bin/$HOST-$tool $PREFIX/$OLD_HOST/bin/$tool || true;
+  ln -s $PREFIX/bin/$HOST-$tool $PREFIX/bin/$OLD_HOST-$tool || true;
 done
+
+rm $PREFIX/bin/$HOST-ld || true;
+rm $PREFIX/bin/$OLD_HOST-ld || true;
+rm $PREFIX/$OLD_HOST/bin/ld || true;
+rm $PREFIX/$HOST/bin/ld || true;
+
+#ln -s $PREFIX/$HOST $PREFIX/$OLD_HOST

--- a/recipe/install_binutils.sh
+++ b/recipe/install_binutils.sh
@@ -10,7 +10,7 @@ export OLD_HOST="${ctng_cpu_arch}-${ctng_vendor}-linux-gnu"
 mkdir -p $PREFIX/$OLD_HOST/bin
 # Remove hardlinks and replace them by softlinks
 for tool in addr2line ar as c++filt dwp elfedit gprof ld.bfd ld.gold nm objcopy objdump ranlib readelf size strings strip; do
-  rm -rf $PREFIX/$HOST/bin/$tool
+  rm -rf $PREFIX/$HOST/bin/$tool || true
   ln -s $PREFIX/bin/$HOST-$tool $PREFIX/$HOST/bin/$tool || true;
   ln -s $PREFIX/bin/$HOST-$tool $PREFIX/$OLD_HOST/bin/$tool || true;
   ln -s $PREFIX/bin/$HOST-$tool $PREFIX/bin/$OLD_HOST-$tool || true;

--- a/recipe/install_binutils_symlinks.sh
+++ b/recipe/install_binutils_symlinks.sh
@@ -3,9 +3,11 @@
 CHOST="${ctng_cpu_arch}-conda-linux-gnu"
 
 for tool in addr2line ar as c++filt dwp elfedit gprof ld ld.bfd ld.gold nm objcopy objdump ranlib readelf size strings strip; do
-  rm $PREFIX/bin/$CHOST-$tool
+  rm -f $PREFIX/bin/$CHOST-$tool || true
   touch $PREFIX/bin/$CHOST-$tool
-  ln -s $PREFIX/bin/$CHOST-$tool $PREFIX/bin/$tool
+  # On s390x dwp and gold support seems not to be present
+  ln -s $PREFIX/bin/$CHOST-$tool $PREFIX/bin/$tool || true
 done
 
-ln -s "$PREFIX/bin/ld.gold" "$PREFIX/bin/gold"
+# Gold support is not present on s390x
+ln -s "$PREFIX/bin/ld.gold" "$PREFIX/bin/gold" || true

--- a/recipe/install_binutils_symlinks.sh
+++ b/recipe/install_binutils_symlinks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CHOST="${ctng_cpu_arch}-${ctng_vendor}-linux-gnu"
+CHOST="${ctng_cpu_arch}-conda-linux-gnu"
 
 for tool in addr2line ar as c++filt dwp elfedit gprof ld ld.bfd ld.gold nm objcopy objdump ranlib readelf size strings strip; do
   rm $PREFIX/bin/$CHOST-$tool

--- a/recipe/install_ld.sh
+++ b/recipe/install_ld.sh
@@ -6,6 +6,12 @@ cd build
 
 make DESTDIR=$PWD/install install-strip
 
-CHOST="${ctng_cpu_arch}-${ctng_vendor}-linux-gnu"
+CHOST="${ctng_cpu_arch}-conda-linux-gnu"
+OLD_CHOST="${ctng_cpu_arch}-${ctng_vendor}-linux-gnu"
 mkdir -p $PREFIX/bin
+mkdir -p $PREFIX/$OLD_CHOST/bin
+mkdir -p $PREFIX/$CHOST/bin
 cp $PWD/install/$PREFIX/bin/$CHOST-ld $PREFIX/bin/$CHOST-ld
+ln -s $PREFIX/bin/$CHOST-ld $PREFIX/bin/$OLD_CHOST-ld
+ln -s $PREFIX/bin/$CHOST-ld $PREFIX/$OLD_CHOST/bin/ld
+ln -s $PREFIX/bin/$CHOST-ld $PREFIX/$CHOST/bin/ld

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "binutils" %}
-{% set version = "2.33.1" %}
+{% set version = "2.35" %}
 {% set chost = ctng_cpu_arch ~ "-" ~ ctng_vendor ~ "-linux-gnu-" %}
+{% set build_num = 9 %}
 
 package:
   name: binutils_split
@@ -8,70 +9,60 @@ package:
 
 source:
   - url: https://ftp.gnu.org/gnu/{{ name }}/{{ name }}-{{ version }}.tar.bz2
-    sha256: 0cb4843da15a65a953907c96bad658283f3c4419d6bcc56bf2789db16306adb2
+    sha256: 7d24660f87093670738e58bcc7b7b06f121c0fcb0ca8fc44368d675a5ef9cff7
     folder: .
 
   # Get the patches from crosstool-ng
-  # Using https://github.com/crosstool-ng/crosstool-ng/pull/1268
-  - url: https://github.com/isuruf/crosstool-ng/archive/931b37a4056fff186052c0e893a6682ab37e7035.tar.gz
-    sha256: b855a87957077c590f5d34754bee04b3a1154202f7823504c88db9eea61f4817
+  - url: https://github.com/crosstool-ng/crosstool-ng/archive/e7da850fa2066c9f1adeba3d8525a7231d0e47bc.tar.gz
+    sha256: ba84dea3109b3fc1d8f7f12ffeade97ba58f62c628b61251db13cf918f55256b
     folder: crosstool_ng
 
 build:
-  number: 7
-  skip: True  # [not linux]
-  detect_binary_files_with_prefix: False
+  number: {{ build_num }}
+  skip: true  # [win]
+  detect_binary_files_with_prefix: false
 
 requirements:
   build:
-    - gcc_bootstrap_{{ target_platform }}
-    - make
-    - texinfo
   host:
   run:
 
 outputs:
-  - name: ld_impl_{{ target_platform }}
+  - name: ld_impl_{{ ctng_target_platform }}
     script: install_ld.sh
     build:
-      merge_build_host: False
-      detect_binary_files_with_prefix: False
+      merge_build_host: false
+      detect_binary_files_with_prefix: false
     requirements:
       build:
-        - gcc_bootstrap_{{ target_platform }}
-        - make
       host:
       run:
+      run_constrained:
+        - binutils_impl_{{ ctng_target_platform }} {{ version }}
     test:
       commands:
         - {{ chost }}ld --help
+        - echo "{{ ctng_vendor }}"
+        - echo {{ c_compiler_version }}
 
-  - name: binutils_impl_{{ target_platform }}
+  - name: binutils_impl_{{ ctng_target_platform }}
     script: install_binutils.sh
     build:
-      merge_build_host: False
-      detect_binary_files_with_prefix: False
+      merge_build_host: false
+      detect_binary_files_with_prefix: false
+      ignore_run_exports:
+        - __glibc
     requirements:
       build:
-        - gcc_bootstrap_{{ target_platform }}
-        - make
       host:
-        - ld_impl_{{ target_platform }}
-        - libstdcxx-ng >={{ cxx_compiler_version }}
-        - libgcc-ng >={{ c_compiler_version }}
+        - ld_impl_{{ ctng_target_platform }} {{ version }}
       run:
-        - {{ pin_subpackage("ld_impl_" ~ target_platform, exact=True) }}
-        - libstdcxx-ng >={{ cxx_compiler_version }}
-        - libgcc-ng >={{ c_compiler_version }}
+        - {{ pin_subpackage("ld_impl_" ~ ctng_target_platform, exact=True) }}
+        - sysroot_{{ ctng_target_platform }}
     test:
-      requires:
-        - gfortran_impl_{{ target_platform }}
-        - gxx_impl_{{ target_platform }}
-        - gcc_impl_{{ target_platform }}
-        - cmake
-        - make
-      files:
-        - tests
+      downstreams:
+        - gfortran_impl_{{ ctng_target_platform }}
+        - gcc_impl_{{ ctng_target_platform }}
       commands:
         - {{ chost }}addr2line --help
         - {{ chost }}ar --help
@@ -90,26 +81,21 @@ outputs:
         - {{ chost }}size --help
         - {{ chost }}strings --help
         - {{ chost }}strip --help
-        - export CC={{ chost }}gcc
-        - export CXX={{ chost }}g++
-        - export FC={{ chost }}gfortran
-        - ${CC} -Wall tests/aligned_alloc.c -o c_aligned -v
-        - ./c_aligned
-        - cd tests/fortomp && cmake .
+        - echo {{ c_compiler_version }}
 
   - name: binutils
     script: install_binutils_symlinks.sh
     build:
-      merge_build_host: False
-      detect_binary_files_with_prefix: False
+      merge_build_host: false
+      detect_binary_files_with_prefix: false
+      skip: true  # [ctng_target_platform != target_platform]
     requirements:
       build:
-        - gcc_bootstrap_{{ target_platform }}
-        - make
       host:
-        - binutils_impl_{{ target_platform }}
+        - binutils_impl_{{ ctng_target_platform }}
       run:
-        - {{ pin_subpackage("binutils_impl_" ~ target_platform, max_pin="x.x.x") }}
+        - {{ pin_subpackage("binutils_impl_" ~ ctng_target_platform, max_pin="x.x.x") }}
+        - libcxx >=4.0.0  # [osx]
     test:
       commands:
         - $PREFIX/bin/addr2line --help
@@ -133,15 +119,19 @@ outputs:
 
 about:
   home: https://www.gnu.org/software/binutils/
-  license: GPL 3
+  license: GPL-3.0-only
   license_file:
     - COPYING
     - COPYING.LIB
     - COPYING3
     - COPYING3.LIB
-  summary: A set of programming tools for creating and managing binary programs, object files, libraries, profile data, and assembly source code.
+  summary: |
+    A set of programming tools for creating and managing binary programs, object files,
+    libraries, profile data, and assembly source code.
 
 extra:
   recipe-maintainers:
     - frol
     - isuruf
+    - jjhelmus
+    - beckermr

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "binutils" %}
-{% set version = "2.35" %}
+{% set version = "2.35.1" %}
 {% set chost = ctng_cpu_arch ~ "-" ~ ctng_vendor ~ "-linux-gnu-" %}
 {% set build_num = 9 %}
 
@@ -9,7 +9,7 @@ package:
 
 source:
   - url: https://ftp.gnu.org/gnu/{{ name }}/{{ name }}-{{ version }}.tar.bz2
-    sha256: 7d24660f87093670738e58bcc7b7b06f121c0fcb0ca8fc44368d675a5ef9cff7
+    sha256: 320e7a1d0f46fcd9f413f1046e216cbe23bb2bce6deb6c6a63304425e48b1942
     folder: .
 
   # Get the patches from crosstool-ng

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
 
 build:
   number: {{ build_num }}
-  skip: true  # [win]
+  skip: true  # [not linux]
   detect_binary_files_with_prefix: false
 
 requirements:
@@ -57,6 +57,8 @@ outputs:
     requirements:
       build:
         - make
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
       host:
       run:
       run_constrained:
@@ -76,6 +78,9 @@ outputs:
         - __glibc
     requirements:
       build:
+        - make
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
       host:
         - ld_impl_{{ ctng_target_platform }} {{ version }}
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   build:
     - gcc_bootstrap_{{ target_platform }}
     - make
+    - texinfo
   host:
   run:
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ source:
 build:
   number: {{ build_num }}
   skip: true  # [win]
+  skip: true  # [not (linux and ppc64le)]
   detect_binary_files_with_prefix: false
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,7 @@ outputs:
       detect_binary_files_with_prefix: false
     requirements:
       build:
+        - make
       host:
       run:
       run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - bash  # [osx]
     - autoconf
     - automake
+    - make                         # [not win]
     - texinfo
     - bison
     - flex

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
   run:
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,7 @@ outputs:
         - {{ chost }}gprof --help
         - {{ chost }}ld --help
         - {{ chost }}ld.bfd --help
-        - {{ chost }}ld.gold --help
+        - {{ chost }}ld.gold --help     # [not s390x]
         - {{ chost }}nm --help
         - {{ chost }}objcopy --help
         - {{ chost }}objdump --help
@@ -103,11 +103,11 @@ outputs:
         - $PREFIX/bin/as --help
         - $PREFIX/bin/c++filt --help
         - $PREFIX/bin/elfedit --help
-        - $PREFIX/bin/gold --help
+        - $PREFIX/bin/gold --help       # [not s390x]
         - $PREFIX/bin/gprof --help
         - $PREFIX/bin/ld --help
         - $PREFIX/bin/ld.bfd --help
-        - $PREFIX/bin/ld.gold --help
+        - $PREFIX/bin/ld.gold --help    # [not s390x]
         - $PREFIX/bin/nm --help
         - $PREFIX/bin/objcopy --help
         - $PREFIX/bin/objdump --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,24 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - bash  # [osx]
+    - autoconf
+    - automake
+    - texinfo
+    - bison
+    - flex
+    - gettext
+    - git
+    - help2man
+    - make
+    - texinfo
+    - unzip
+    - wget
+    - libtool
+    - flex
+    - bison
+    - ncurses
+    - patch  # [unix]
   host:
   run:
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ source:
 build:
   number: {{ build_num }}
   skip: true  # [win]
-  skip: true  # [not (linux and ppc64le)]
   detect_binary_files_with_prefix: false
 
 requirements:

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,0 +1,4 @@
+texinfo
+make
+gcc-c++
+binutils

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,1 +1,0 @@
-texinfo


### PR DESCRIPTION
To solve dependency conflict error between older gcc versions and python 3.11