### PR TITLE
binutils 2.40

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,38 +1,37 @@
-ctng_target_platform:
+ctng_target_platform:  # [unix]
   - osx-64            # [osx and x86_64]
   - osx-arm64         # [osx and arm64]
   - linux-aarch64     # [aarch64]
   - linux-64          # [linux and x86_64]
   - linux-s390x       # [linux and s390x]
   - linux-ppc64le     # [linux and ppc64le]
-ctng_cpu_arch:
+ctng_cpu_arch:        # [unix]
   - x86_64            # [x86_64]
   - aarch64           # [aarch64]
   - arm64             # [arm64]
   - s390x             # [s390x]
   - powerpc64le       # [ppc64le]
-ctng_vendor:
+ctng_vendor:          # [unix]
   - apple             # [osx]
   - conda             # [linux]
-ctng_vendor_old:
-  - apple            # [osx]
-  - conda_cos7       # [linux]
-ctng_os:
+ctng_vendor_old:      # [unix]
+  - apple             # [osx]
+  - conda_cos7        # [linux]
+ctng_os:              # [unix]
   - darwin13.4.0      # [osx and x86_64]
   - darwin20.0.0      # [osx and arm64]
   - linux-gnu         # [linux]
-ctng_triplet:
+ctng_triplet:         # [unix]
   - x86_64-apple-darwin13.4.0  # [osx and x86_64]
   - arm64-apple-darwin20.0.0   # [osx and arm64]
   - aarch64-conda-linux-gnu    # [linux and aarch64]
   - x86_64-conda-linux-gnu     # [linux and x86_64]
   - s390x-conda-linux-gnu      # [linux and s390x]
   - powerpc64le-conda-linux-gnu    # [linux and ppc64le]
-ctng_triplet_old:
+ctng_triplet_old:                   # [unix]
   - x86_64-apple-darwin13.4.0       # [osx and x86_64]
   - arm64-apple-darwin20.0.0        # [osx and arm64]
   - aarch64-conda_cos7-linux-gnu    # [linux and aarch64]
   - x86_64-conda_cos7-linux-gnu     # [linux and x86_64]
   - s390x-conda_cos7-linux-gnu      # [linux and s390x]
   - powerpc64le-conda_cos7-linux-gnu    # [linux and ppc64le]
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.38" %}
+{% set version = "2.43.1" %}
 {% set sha256 = "e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024" %}
 {% set chost = ctng_cpu_arch ~ "-" ~ ctng_vendor_old ~ "-" ~ ctng_os ~ "-" %}
 
@@ -8,7 +8,7 @@ package:
 
 source:
   - url: https://ftp.gnu.org/gnu/binutils/binutils-{{ version }}.tar.xz
-    sha256: {{ sha256 }}
+    sha256: f8298eb153a4b37d112e945aa5cb2850040bcf26a3ea65b5a715c83afe05e48a
     folder: binutils
     patches:
       - patches/binutils/0000-sh-conf.patch
@@ -22,7 +22,7 @@ source:
       - patches/binutils/0008-binutils-2.38-vs.-ppc32-linux-kernel.patch
       - patches/binutils/0009-fix-align-kernel.patch
 build:
-  number: 1
+  number: 0
   # binutils support on osx is not fully implemented
   skip: true  # [not linux]
   detect_binary_files_with_prefix: false
@@ -145,6 +145,7 @@ outputs:
 
 about:
   home: https://www.gnu.org/software/binutils/
+  dev_url: https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git
   license: GPL-3.0-only
   license_file:
     - binutils/COPYING
@@ -158,4 +159,3 @@ about:
 extra:
   recipe-maintainers:
     - katietz
- 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
       - patches/binutils/0005-Darwin-Two-fixes-from-Android-NDK-PTHREAD_ONCE_INIT-wcsncasecmp.patch
       - patches/binutils/0006-sysroot.patch
       - patches/binutils/0007-poison-system-directories.patch
-      - patches/binutils/0008-binutils-2.38-vs.-ppc32-linux-kernel.patch
+      #- patches/binutils/0008-binutils-2.38-vs.-ppc32-linux-kernel.patch
       - patches/binutils/0009-fix-align-kernel.patch
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
       - patches/binutils/0005-Darwin-Two-fixes-from-Android-NDK-PTHREAD_ONCE_INIT-wcsncasecmp.patch
       - patches/binutils/0006-sysroot.patch
       #- patches/binutils/0007-poison-system-directories.patch
-      - patches/binutils/0008-binutils-2.38-vs.-ppc32-linux-kernel.patch
+      #- patches/binutils/0008-binutils-2.38-vs.-ppc32-linux-kernel.patch
       - patches/binutils/0009-fix-align-kernel.patch
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://ftp.gnu.org/gnu/binutils/binutils-{{ version }}.tar.xz
-    sha256: 13f74202a3c4c51118b797a39ea4200d3f6cfbe224da6d1d95bb938480132dfd
+    sha256: 0f8a4c272d7f17f369ded10a4aca28b8e304828e95526da482b0ccc4dfc9d8e1
     folder: binutils
     patches:
       - patches/binutils/0000-sh-conf.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - patches/binutils/0004-Darwin-gold-binary-cc-include-string-not-cstring.patch
       - patches/binutils/0005-Darwin-Two-fixes-from-Android-NDK-PTHREAD_ONCE_INIT-wcsncasecmp.patch
       - patches/binutils/0006-sysroot.patch
-      - patches/binutils/0007-poison-system-directories.patch
+      #- patches/binutils/0007-poison-system-directories.patch
       - patches/binutils/0008-binutils-2.38-vs.-ppc32-linux-kernel.patch
       - patches/binutils/0009-fix-align-kernel.patch
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set version = "2.43.1" %}
-{% set sha256 = "e316477a914f567eccc34d5d29785b8b0f5a10208d36bbacedcc39048ecfe024" %}
 {% set chost = ctng_cpu_arch ~ "-" ~ ctng_vendor_old ~ "-" ~ ctng_os ~ "-" %}
 
 package:
@@ -8,7 +7,7 @@ package:
 
 source:
   - url: https://ftp.gnu.org/gnu/binutils/binutils-{{ version }}.tar.xz
-    sha256: f8298eb153a4b37d112e945aa5cb2850040bcf26a3ea65b5a715c83afe05e48a
+    sha256: 13f74202a3c4c51118b797a39ea4200d3f6cfbe224da6d1d95bb938480132dfd
     folder: binutils
     patches:
       - patches/binutils/0000-sh-conf.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
       - patches/binutils/0006-sysroot.patch
       #- patches/binutils/0007-poison-system-directories.patch
       #- patches/binutils/0008-binutils-2.38-vs.-ppc32-linux-kernel.patch
-      - patches/binutils/0009-fix-align-kernel.patch
+     #- patches/binutils/0009-fix-align-kernel.patch
 build:
   number: 0
   # binutils support on osx is not fully implemented

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.43.1" %}
+{% set version = "2.40" %}
 {% set chost = ctng_cpu_arch ~ "-" ~ ctng_vendor_old ~ "-" ~ ctng_os ~ "-" %}
 
 package:
@@ -17,9 +17,9 @@ source:
       - patches/binutils/0004-Darwin-gold-binary-cc-include-string-not-cstring.patch
       - patches/binutils/0005-Darwin-Two-fixes-from-Android-NDK-PTHREAD_ONCE_INIT-wcsncasecmp.patch
       - patches/binutils/0006-sysroot.patch
-      #- patches/binutils/0007-poison-system-directories.patch
-      #- patches/binutils/0008-binutils-2.38-vs.-ppc32-linux-kernel.patch
-     #- patches/binutils/0009-fix-align-kernel.patch
+      - patches/binutils/0007-poison-system-directories.patch
+      - patches/binutils/0008-binutils-2.38-vs.-ppc32-linux-kernel.patch
+      - patches/binutils/0009-fix-align-kernel.patch
 build:
   number: 0
   # binutils support on osx is not fully implemented

--- a/recipe/patches/binutils/0007-poison-system-directories.patch
+++ b/recipe/patches/binutils/0007-poison-system-directories.patch
@@ -1,79 +1,25 @@
-Patch adapted to binutils 2.23.2 and extended to use
-BR_COMPILER_PARANOID_UNSAFE_PATH by Thomas Petazzoni.
-
-[Gustavo: adapt to binutils 2.25]
-Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
-Signed-off-by: Gustavo Zacarias <gustavo@zacarias.com.ar>
-
-Upstream-Status: Inappropriate [distribution: codesourcery]
-
-Patch originally created by Mark Hatle, forward-ported to
-binutils 2.21 by Scott Garman.
-
-purpose:  warn for uses of system directories when cross linking
-
-Code Merged from Sourcery G++ binutils 2.19 - 4.4-277
-
-2008-07-02  Joseph Myers  <joseph@codesourcery.com>
-
-    ld/
-    * ld.h (args_type): Add error_poison_system_directories.
-    * ld.texinfo (--error-poison-system-directories): Document.
-    * ldfile.c (ldfile_add_library_path): Check
-    command_line.error_poison_system_directories.
-    * ldmain.c (main): Initialize
-    command_line.error_poison_system_directories.
-    * lexsup.c (enum option_values): Add
-    OPTION_ERROR_POISON_SYSTEM_DIRECTORIES.
-    (ld_options): Add --error-poison-system-directories.
-    (parse_args): Handle new option.
-
-2007-06-13  Joseph Myers  <joseph@codesourcery.com>
-
-    ld/
-    * config.in: Regenerate.
-    * ld.h (args_type): Add poison_system_directories.
-    * ld.texinfo (--no-poison-system-directories): Document.
-    * ldfile.c (ldfile_add_library_path): Check
-    command_line.poison_system_directories.
-    * ldmain.c (main): Initialize
-    command_line.poison_system_directories.
-    * lexsup.c (enum option_values): Add
-    OPTION_NO_POISON_SYSTEM_DIRECTORIES.
-    (ld_options): Add --no-poison-system-directories.
-    (parse_args): Handle new option.
-
-2007-04-20  Joseph Myers  <joseph@codesourcery.com>
-
-    Merge from Sourcery G++ binutils 2.17:
-
-    2007-03-20  Joseph Myers  <joseph@codesourcery.com>
-    Based on patch by Mark Hatle <mark.hatle@windriver.com>.
-    ld/
-    * configure.ac (--enable-poison-system-directories): New option.
-    * configure, config.in: Regenerate.
-    * ldfile.c (ldfile_add_library_path): If
-    ENABLE_POISON_SYSTEM_DIRECTORIES defined, warn for use of /lib,
-    /usr/lib, /usr/local/lib or /usr/X11R6/lib.
-
-Signed-off-by: Mark Hatle <mark.hatle@windriver.com>
-Signed-off-by: Scott Garman <scott.a.garman@intel.com>
+From bc4856725abb3f7bd50476d84691a5b07c167bf4 Mon Sep 17 00:00:00 2001
+From: Serhii Kupriienko <skupriienko@anaconda.com>
+Date: Thu, 19 Sep 2024 13:40:09 +0300
+Subject: [PATCH] Resolve merge conflict
 
 ---
- ld/config.in    |    3 +++
- ld/configure    |   14 ++++++++++++++
- ld/configure.ac |   10 ++++++++++
- ld/ld.h         |    8 ++++++++
- ld/ld.texi      |   12 ++++++++++++
- ld/ldfile.c     |   17 +++++++++++++++++
- ld/ldlex.h      |    2 ++
- ld/ldmain.c     |    2 ++
- ld/lexsup.c     |   21 +++++++++++++++++++++
+ ld/config.in    |  3 +++
+ ld/configure    | 14 ++++++++++++++
+ ld/configure.ac | 10 ++++++++++
+ ld/ld.h         |  8 ++++++++
+ ld/ld.texi      | 12 ++++++++++++
+ ld/ldfile.c     | 17 +++++++++++++++++
+ ld/ldlex.h      |  2 ++
+ ld/ldmain.c     |  2 ++
+ ld/lexsup.c     | 21 +++++++++++++++++++++
  9 files changed, 89 insertions(+)
 
+diff --git a/ld/config.in b/ld/config.in
+index ad0dc6a106c..d21edaddce7 100644
 --- a/ld/config.in
 +++ b/ld/config.in
-@@ -43,6 +43,9 @@
+@@ -58,6 +58,9 @@
     language is requested. */
  #undef ENABLE_NLS
  
@@ -83,9 +29,11 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
  /* Additional extension a shared object might have. */
  #undef EXTRA_SHLIB_EXTENSION
  
+diff --git a/ld/configure b/ld/configure
+index 43b44be1dc6..28f054ea3f8 100755
 --- a/ld/configure
 +++ b/ld/configure
-@@ -831,6 +831,7 @@
+@@ -839,6 +839,7 @@ with_lib_path
  enable_targets
  enable_64_bit_bfd
  with_sysroot
@@ -93,7 +41,7 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
  enable_gold
  enable_got
  enable_compressed_debug_sections
-@@ -1500,6 +1501,8 @@
+@@ -1521,6 +1522,8 @@ Optional Features:
    --enable-checking       enable run-time checks
    --enable-targets        alternative target configurations
    --enable-64-bit-bfd     64-bit support (on hosts with narrower word sizes)
@@ -102,7 +50,7 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
    --enable-gold[=ARG]     build gold [ARG={default,yes,no}]
    --enable-got=<type>     GOT handling scheme (target, single, negative,
                            multigot)
-@@ -15333,7 +15336,18 @@
+@@ -15504,7 +15507,18 @@ else
  fi
  
  
@@ -121,9 +69,11 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
  
  # Check whether --enable-got was given.
  if test "${enable_got+set}" = set; then :
+diff --git a/ld/configure.ac b/ld/configure.ac
+index 77edac3258c..a74dac63038 100644
 --- a/ld/configure.ac
 +++ b/ld/configure.ac
-@@ -102,6 +102,16 @@
+@@ -103,6 +103,16 @@ AC_SUBST(use_sysroot)
  AC_SUBST(TARGET_SYSTEM_ROOT)
  AC_SUBST(TARGET_SYSTEM_ROOT_DEFINE)
  
@@ -140,9 +90,11 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
  dnl Use --enable-gold to decide if this linker should be the default.
  dnl "install_as_default" is set to false if gold is the default linker.
  dnl "installed_linker" is the installed BFD linker name.
+diff --git a/ld/ld.h b/ld/ld.h
+index 05649ff61b8..bb00ebec658 100644
 --- a/ld/ld.h
 +++ b/ld/ld.h
-@@ -157,6 +157,14 @@
+@@ -158,6 +158,14 @@ typedef struct
    /* If set, display the target memory usage (per memory region).  */
    bool print_memory_usage;
  
@@ -157,13 +109,14 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
    /* Should we force section groups to be resolved?  Controlled with
       --force-group-allocation on the command line or FORCE_GROUP_ALLOCATION
       in the linker script.  */
+diff --git a/ld/ld.texi b/ld/ld.texi
+index db3a9f09b45..9dacc934f80 100644
 --- a/ld/ld.texi
 +++ b/ld/ld.texi
-@@ -2892,6 +2892,18 @@
- 
+@@ -2949,6 +2949,18 @@ string identifying the original linked file does not change.
  Passing @code{none} for @var{style} disables the setting from any
  @code{--build-id} options earlier on the command line.
-+
+ 
 +@kindex --no-poison-system-directories
 +@item --no-poison-system-directories
 +Do not warn for @option{-L} options using system directories such as
@@ -175,12 +128,15 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
 +@item --error-poison-system-directories
 +Give an error instead of a warning for @option{-L} options using
 +system directories when cross linking.
- @end table
- 
- @c man end
++
+ @kindex --package-metadata=@var{JSON}
+ @item --package-metadata=@var{JSON}
+ Request the creation of a @code{.note.package} ELF note section.  The
+diff --git a/ld/ldfile.c b/ld/ldfile.c
+index b8fd4e5d8e0..1f1d8e23bc9 100644
 --- a/ld/ldfile.c
 +++ b/ld/ldfile.c
-@@ -117,6 +117,23 @@
+@@ -117,6 +117,23 @@ ldfile_add_library_path (const char *name, bool cmdline)
      new_dirs->name = concat (ld_sysroot, name + strlen ("$SYSROOT"), (const char *) NULL);
    else
      new_dirs->name = xstrdup (name);
@@ -204,20 +160,24 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
  }
  
  /* Try to open a BFD for a lang_input_statement.  */
+diff --git a/ld/ldlex.h b/ld/ldlex.h
+index 0538f0a06a1..d1de3aec23d 100644
 --- a/ld/ldlex.h
 +++ b/ld/ldlex.h
-@@ -164,6 +164,8 @@
+@@ -166,6 +166,8 @@ enum option_values
    OPTION_CTF_VARIABLES,
    OPTION_NO_CTF_VARIABLES,
    OPTION_CTF_SHARE_TYPES,
 +  OPTION_NO_POISON_SYSTEM_DIRECTORIES,
 +  OPTION_ERROR_POISON_SYSTEM_DIRECTORIES,
- };
- 
- /* The initial parser states.  */
+   OPTION_WARN_EXECSTACK,
+   OPTION_NO_WARN_EXECSTACK,
+   OPTION_WARN_RWX_SEGMENTS,
+diff --git a/ld/ldmain.c b/ld/ldmain.c
+index 9290a189b0d..92e031a6091 100644
 --- a/ld/ldmain.c
 +++ b/ld/ldmain.c
-@@ -321,6 +321,8 @@
+@@ -321,6 +321,8 @@ main (int argc, char **argv)
    command_line.warn_mismatch = true;
    command_line.warn_search_mismatch = true;
    command_line.check_section_addresses = -1;
@@ -226,9 +186,11 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
  
    /* We initialize DEMANGLING based on the environment variable
       COLLECT_NO_DEMANGLE.  The gcc collect2 program will demangle the
+diff --git a/ld/lexsup.c b/ld/lexsup.c
+index c5960385572..da0a7829914 100644
 --- a/ld/lexsup.c
 +++ b/ld/lexsup.c
-@@ -600,6 +600,14 @@
+@@ -613,6 +613,14 @@ static const struct ld_option ld_options[] =
  		   "                                <method> is: share-unconflicted (default),\n"
  		   "                                             share-duplicated"),
      TWO_DASHES },
@@ -243,7 +205,7 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
  };
  
  #define OPTION_COUNT ARRAY_SIZE (ld_options)
-@@ -612,6 +620,7 @@
+@@ -625,6 +633,7 @@ parse_args (unsigned argc, char **argv)
    int ingroup = 0;
    char *default_dirlist = NULL;
    char *shortopts;
@@ -251,7 +213,7 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
    struct option *longopts;
    struct option *really_longopts;
    int last_optind;
-@@ -1659,6 +1668,14 @@
+@@ -1692,6 +1701,14 @@ parse_args (unsigned argc, char **argv)
  	  }
  	  break;
  
@@ -266,7 +228,7 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
  	case OPTION_PUSH_STATE:
  	  input_flags.pushed = xmemdup (&input_flags,
  					sizeof (input_flags),
-@@ -1804,6 +1821,10 @@
+@@ -1837,6 +1854,10 @@ parse_args (unsigned argc, char **argv)
        command_line.soname = NULL;
      }
  
@@ -277,3 +239,6 @@ Signed-off-by: Scott Garman <scott.a.garman@intel.com>
    while (ingroup)
      {
        einfo (_("%P: missing --end-group; added as last command line option\n"));
+-- 
+2.45.2
+

--- a/recipe/patches/binutils/0007-poison-system-directories.patch
+++ b/recipe/patches/binutils/0007-poison-system-directories.patch
@@ -1,7 +1,63 @@
-From 8917d1d32a204870695bd08be979877254a791d0 Mon Sep 17 00:00:00 2001
-From: Serhii Kupriienko <skupriienko@anaconda.com>
-Date: Thu, 19 Sep 2024 13:51:31 +0300
-Subject: [PATCH] Resolve merge conflict
+Patch adapted to binutils 2.23.2 and extended to use
+BR_COMPILER_PARANOID_UNSAFE_PATH by Thomas Petazzoni.
+
+[Gustavo: adapt to binutils 2.25]
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+Signed-off-by: Gustavo Zacarias <gustavo@zacarias.com.ar>
+
+Upstream-Status: Inappropriate [distribution: codesourcery]
+
+Patch originally created by Mark Hatle, forward-ported to
+binutils 2.21 by Scott Garman.
+
+purpose:  warn for uses of system directories when cross linking
+
+Code Merged from Sourcery G++ binutils 2.19 - 4.4-277
+
+2008-07-02  Joseph Myers  <joseph@codesourcery.com>
+
+    ld/
+    * ld.h (args_type): Add error_poison_system_directories.
+    * ld.texinfo (--error-poison-system-directories): Document.
+    * ldfile.c (ldfile_add_library_path): Check
+    command_line.error_poison_system_directories.
+    * ldmain.c (main): Initialize
+    command_line.error_poison_system_directories.
+    * lexsup.c (enum option_values): Add
+    OPTION_ERROR_POISON_SYSTEM_DIRECTORIES.
+    (ld_options): Add --error-poison-system-directories.
+    (parse_args): Handle new option.
+
+2007-06-13  Joseph Myers  <joseph@codesourcery.com>
+
+    ld/
+    * config.in: Regenerate.
+    * ld.h (args_type): Add poison_system_directories.
+    * ld.texinfo (--no-poison-system-directories): Document.
+    * ldfile.c (ldfile_add_library_path): Check
+    command_line.poison_system_directories.
+    * ldmain.c (main): Initialize
+    command_line.poison_system_directories.
+    * lexsup.c (enum option_values): Add
+    OPTION_NO_POISON_SYSTEM_DIRECTORIES.
+    (ld_options): Add --no-poison-system-directories.
+    (parse_args): Handle new option.
+
+2007-04-20  Joseph Myers  <joseph@codesourcery.com>
+
+    Merge from Sourcery G++ binutils 2.17:
+
+    2007-03-20  Joseph Myers  <joseph@codesourcery.com>
+    Based on patch by Mark Hatle <mark.hatle@windriver.com>.
+    ld/
+    * configure.ac (--enable-poison-system-directories): New option.
+    * configure, config.in: Regenerate.
+    * ldfile.c (ldfile_add_library_path): If
+    ENABLE_POISON_SYSTEM_DIRECTORIES defined, warn for use of /lib,
+    /usr/lib, /usr/local/lib or /usr/X11R6/lib.
+
+Signed-off-by: Mark Hatle <mark.hatle@windriver.com>
+Signed-off-by: Scott Garman <scott.a.garman@intel.com>
 
 ---
  ld/config.in    |  3 +++

--- a/recipe/patches/binutils/0007-poison-system-directories.patch
+++ b/recipe/patches/binutils/0007-poison-system-directories.patch
@@ -1,6 +1,6 @@
-From bc4856725abb3f7bd50476d84691a5b07c167bf4 Mon Sep 17 00:00:00 2001
+From 8917d1d32a204870695bd08be979877254a791d0 Mon Sep 17 00:00:00 2001
 From: Serhii Kupriienko <skupriienko@anaconda.com>
-Date: Thu, 19 Sep 2024 13:40:09 +0300
+Date: Thu, 19 Sep 2024 13:51:31 +0300
 Subject: [PATCH] Resolve merge conflict
 
 ---
@@ -110,13 +110,14 @@ index 05649ff61b8..bb00ebec658 100644
       --force-group-allocation on the command line or FORCE_GROUP_ALLOCATION
       in the linker script.  */
 diff --git a/ld/ld.texi b/ld/ld.texi
-index db3a9f09b45..9dacc934f80 100644
+index db3a9f09b45..77037399cb9 100644
 --- a/ld/ld.texi
 +++ b/ld/ld.texi
-@@ -2949,6 +2949,18 @@ string identifying the original linked file does not change.
- Passing @code{none} for @var{style} disables the setting from any
- @code{--build-id} options earlier on the command line.
- 
+@@ -2960,6 +2960,18 @@ creation of the metadata note, if one had been enabled by an earlier
+ occurrence of the --package-metdata option.
+ If the linker has been built with libjansson, then the JSON string
+ will be validated.
++
 +@kindex --no-poison-system-directories
 +@item --no-poison-system-directories
 +Do not warn for @option{-L} options using system directories such as
@@ -128,10 +129,9 @@ index db3a9f09b45..9dacc934f80 100644
 +@item --error-poison-system-directories
 +Give an error instead of a warning for @option{-L} options using
 +system directories when cross linking.
-+
- @kindex --package-metadata=@var{JSON}
- @item --package-metadata=@var{JSON}
- Request the creation of a @code{.note.package} ELF note section.  The
+ @end table
+ 
+ @c man end
 diff --git a/ld/ldfile.c b/ld/ldfile.c
 index b8fd4e5d8e0..1f1d8e23bc9 100644
 --- a/ld/ldfile.c
@@ -161,18 +161,18 @@ index b8fd4e5d8e0..1f1d8e23bc9 100644
  
  /* Try to open a BFD for a lang_input_statement.  */
 diff --git a/ld/ldlex.h b/ld/ldlex.h
-index 0538f0a06a1..d1de3aec23d 100644
+index 0538f0a06a1..f94a71875d8 100644
 --- a/ld/ldlex.h
 +++ b/ld/ldlex.h
-@@ -166,6 +166,8 @@ enum option_values
-   OPTION_CTF_VARIABLES,
-   OPTION_NO_CTF_VARIABLES,
-   OPTION_CTF_SHARE_TYPES,
-+  OPTION_NO_POISON_SYSTEM_DIRECTORIES,
-+  OPTION_ERROR_POISON_SYSTEM_DIRECTORIES,
-   OPTION_WARN_EXECSTACK,
+@@ -170,6 +170,8 @@ enum option_values
    OPTION_NO_WARN_EXECSTACK,
    OPTION_WARN_RWX_SEGMENTS,
+   OPTION_NO_WARN_RWX_SEGMENTS,
++  OPTION_NO_POISON_SYSTEM_DIRECTORIES,
++  OPTION_ERROR_POISON_SYSTEM_DIRECTORIES,
+ };
+ 
+ /* The initial parser states.  */
 diff --git a/ld/ldmain.c b/ld/ldmain.c
 index 9290a189b0d..92e031a6091 100644
 --- a/ld/ldmain.c

--- a/recipe/patches/binutils/0009-fix-align-kernel.patch
+++ b/recipe/patches/binutils/0009-fix-align-kernel.patch
@@ -1,21 +1,28 @@
-Index: binutils-2.38/bfd/elf.c
-===================================================================
---- binutils-2.38.orig/bfd/elf.c
-+++ binutils-2.38/bfd/elf.c
-@@ -5435,8 +5435,10 @@ assign_file_positions_for_load_sections
+From 79dc6f27012c442cd4a18c2296eada39164f2ac9 Mon Sep 17 00:00:00 2001
+From: Serhii Kupriienko <skupriienko@anaconda.com>
+Date: Thu, 19 Sep 2024 14:20:09 +0300
+Subject: [PATCH] Resolve merge conflict
+
+---
+ bfd/elf.c | 18 +++++++++++++++---
+ 1 file changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/bfd/elf.c b/bfd/elf.c
+index a82a1dd60a6..6ae7fa57622 100644
+--- a/bfd/elf.c
++++ b/bfd/elf.c
+@@ -5433,6 +5433,8 @@ assign_file_positions_for_load_sections (bfd *abfd,
    Elf_Internal_Phdr *p;
    file_ptr off;  /* Octets.  */
    bfd_size_type maxpagesize;
 +  bfd_size_type commonpagesize;
-   bfd_size_type p_align;
-   bool p_align_p = false;
 +  bool p_align_commonpagesize_p = false;
    unsigned int alloc, actual;
    unsigned int i, j;
    struct elf_segment_map **sorted_seg_map;
-@@ -5523,12 +5525,19 @@ assign_file_positions_for_load_sections
+@@ -5518,12 +5520,19 @@ assign_file_positions_for_load_sections (bfd *abfd,
+ 	   elf_sort_segments);
  
-   p_align = bed->p_align;
    maxpagesize = 1;
 +  commonpagesize = 1;
    if ((abfd->flags & D_PAGED) != 0)
@@ -35,7 +42,7 @@ Index: binutils-2.38/bfd/elf.c
      }
  
    /* Sections must map to file offsets past the ELF file header.  */
-@@ -5600,7 +5609,7 @@ assign_file_positions_for_load_sections
+@@ -5599,7 +5608,7 @@ assign_file_positions_for_load_sections (bfd *abfd,
  	       largest section alignment.  The run-time loader can
  	       align segments to the default p_align value or the
  	       maximum page size, depending on system page size.  */
@@ -44,7 +51,7 @@ Index: binutils-2.38/bfd/elf.c
  
  	  p->p_align = maxpagesize;
  	}
-@@ -6035,6 +6044,9 @@ assign_file_positions_for_load_sections
+@@ -6035,6 +6044,9 @@ assign_file_positions_for_load_sections (bfd *abfd,
  
  	  if (p_align_p)
  	    p->p_align = p_align;
@@ -54,3 +61,6 @@ Index: binutils-2.38/bfd/elf.c
  	}
      }
  
+-- 
+2.45.2
+

--- a/recipe/patches/binutils/0009-fix-align-kernel.patch
+++ b/recipe/patches/binutils/0009-fix-align-kernel.patch
@@ -1,8 +1,5 @@
-From 79dc6f27012c442cd4a18c2296eada39164f2ac9 Mon Sep 17 00:00:00 2001
-From: Serhii Kupriienko <skupriienko@anaconda.com>
-Date: Thu, 19 Sep 2024 14:20:09 +0300
-Subject: [PATCH] Resolve merge conflict
-
+Index: binutils-2.38/bfd/elf.c
+===================================================================
 ---
  bfd/elf.c | 18 +++++++++++++++---
  1 file changed, 15 insertions(+), 3 deletions(-)


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5374](https://anaconda.atlassian.net/browse/PKG-5374) 
- [Upstream repository](https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git)

### Explanation of changes:

- Disable 0008-binutils-2.38-vs.-ppc32-linux-kernel.patch as the issue is already fixed by the upstream
- Refresh two patches to be compatible with v2.40
- Add dev_url

### Notes:

- Updating to address CVE-2023-25584 because it affects binutils <2.40. I do not update to the latest version as it can have breaking changes. conda-forge also has 2.40. 
- As we skip `win-64` you can ignore the build failed on `win`. The reason for failing is that `conda-build` renders the recipe and finds an undefined jinja variable before it parses the `build/skip` section.

[PKG-5374]: https://anaconda.atlassian.net/browse/PKG-5374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ