### PR TITLE
binutils 2.44 set -u rework

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
       - patches/0009-fix-align-kernel.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win64 and cross_target_platform != "win-64"]
   detect_binary_files_with_prefix: false
 
@@ -26,9 +26,9 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
-    - make                    # [unix]
-    - texinfo                 # [unix]
-    - flex                    # [unix]
+    - make
+    - texinfo
+    - flex                    # [osx]
   host:
   run:
 

--- a/recipe/scripts/activate-binutils.sh
+++ b/recipe/scripts/activate-binutils.sh
@@ -65,8 +65,8 @@ _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         thing=$(echo "${thing}" | tr 'a-z+-.' 'A-ZX__')
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'

--- a/recipe/scripts/deactivate-binutils.sh
+++ b/recipe/scripts/deactivate-binutils.sh
@@ -65,8 +65,8 @@ _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         thing=$(echo "${thing}" | tr 'a-z+-.' 'A-ZX__')
-        eval oldval="\$${from}$thing"
-        if [ -n "${oldval}" ]; then
+        eval oldval="\${${from}$thing:-}"
+        if [ -n "${oldval:-}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
           eval unset '${to}${thing}'


### PR DESCRIPTION
binutils 2.44 

**Destination channel:** Defaults

### Links

- [PKG-12890]
- dev_url:        https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git
- conda_forge:    https://github.com/conda-forge/binutils-feedstock
- pypi:           https://pypi.org/project/binutils/2.44
- pypi inspector: https://inspector.pypi.io/project/binutils/2.44

### Explanation of changes:

- conda 26.1.0 changes how activation scripts are run -- now altogether
- `gdb`'s `post-link.sh` has a `set -u`
- `conda create -n foo -y gdb gcc_<target-platform>` will fail
- cf. https://github.com/conda-forge/binutils-feedstock/pull/109


[PKG-12890]: https://anaconda.atlassian.net/browse/PKG-12890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ