### PR TITLE
Add ld_impl_osx-arm64 to anaconda.yaml packages

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,19 +1,15 @@
 anaconda_config_version: 1
 upstream_sources:
-- webpage:
-    url: https://ftpmirror.gnu.org/binutils/
-    regex: binutils-([\d.]+)\.tar\.xz
-  packages:
-  - binutils
-  - binutils_impl_linux-64
-  - binutils_impl_linux-aarch64
-  - binutils_impl_osx-arm64
-  - binutils_impl_win-64
-  - binutils_linux-64
-  - binutils_linux-aarch64
-  - binutils_osx-arm64
-  - binutils_win-64
-  - ld_impl_linux-64
-  - ld_impl_linux-aarch64
-  - ld_impl_osx-arm64
-  - ld_impl_win-64
+  - webpage:
+      url: https://ftpmirror.gnu.org/binutils/
+      regex: binutils-([\d.]+)\.tar\.xz
+    packages:
+      - binutils
+      - binutils_impl_linux-64
+      - binutils_impl_linux-aarch64
+      - binutils_impl_osx-arm64
+      - binutils_linux-64
+      - binutils_linux-aarch64
+      - binutils_osx-arm64
+      - ld_impl_linux-64
+      - ld_impl_linux-aarch64

--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,18 +1,19 @@
 anaconda_config_version: 1
 upstream_sources:
-  - webpage:
-      url: https://ftpmirror.gnu.org/binutils/
-      regex: binutils-([\d.]+)\.tar\.xz
-    packages:
-      - binutils
-      - binutils_impl_linux-64
-      - binutils_impl_linux-aarch64
-      - binutils_impl_osx-arm64
-      - binutils_impl_win-64
-      - binutils_linux-64
-      - binutils_linux-aarch64
-      - binutils_osx-arm64
-      - binutils_win-64
-      - ld_impl_linux-64
-      - ld_impl_linux-aarch64
-      - ld_impl_win-64
+- webpage:
+    url: https://ftpmirror.gnu.org/binutils/
+    regex: binutils-([\d.]+)\.tar\.xz
+  packages:
+  - binutils
+  - binutils_impl_linux-64
+  - binutils_impl_linux-aarch64
+  - binutils_impl_osx-arm64
+  - binutils_impl_win-64
+  - binutils_linux-64
+  - binutils_linux-aarch64
+  - binutils_osx-arm64
+  - binutils_win-64
+  - ld_impl_linux-64
+  - ld_impl_linux-aarch64
+  - ld_impl_osx-arm64
+  - ld_impl_win-64


### PR DESCRIPTION
## Summary
- Retarget binutils config work to **`main`** (default branch).
- Add missing `ld_impl_osx-arm64` to the explicit `packages` list in `anaconda.yaml`.

## Context
- Previous PR #13 was opened against `master` because aggregate submodule branch metadata overrides `--git-base main` in the feedstock config generator.
- `main` already had `anaconda.yaml`; this PR is a minimal packages fix on top of `main`.

## Test plan
- [ ] nvchecker validates all listed package outputs

Made with [Cursor](https://cursor.com)